### PR TITLE
Update VerifyShopify.php

### DIFF
--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -317,7 +317,10 @@ class VerifyShopify
     {
         return Redirect::route(
             Util::getShopifyConfig('route_names.authenticate'),
-            ['shop' => $shopDomain->toNative()]
+            [
+                'shop' => $shopDomain->toNative(),
+                'host' => request('host'),
+            ]
         );
     }
 


### PR DESCRIPTION
Fix for host param not being passed. Param is required for app bridge.